### PR TITLE
fix(ci): serialize deploy workflow runs to prevent S3 sync races

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to the deploy workflow so pushes to `main` queue sequentially instead of racing.
- Without this, a burst of merges (e.g. Dependabot cleanup) fires overlapping runs whose `aws s3 sync --delete` steps step on each other, deleting hashed assets a not-yet-refreshed `index.html` still references — the exact MIME-type breakage seen on bookrage001.com today.

## Test plan
- [x] YAML is valid (concurrency block placed correctly)
- Next push to main will confirm runs queue instead of overlapping